### PR TITLE
auto-swipe stopped after swipe-left/right by touch

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -421,6 +421,8 @@
           }
 
         }
+        
+        delay = options.auto || 0;
 
         // kill touchmove and touchend event listeners until touchstart called again
         element.removeEventListener('touchmove', events, false);


### PR DESCRIPTION
I set auto to 1000. Without any touch, it works well.

But after I swipe left or right by touch-move, it fails to auto swipe.
