### PR TITLE
fix android 4.* will trigger transitionEnd more than one time

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -223,7 +223,7 @@
     var interval;
 
     function begin() {
-
+      clearTimeout(interval);
       interval = setTimeout(next, delay);
 
     }


### PR DESCRIPTION
options.auto equal to 1000, more than 3 slides.
There is something wrong on android 4.4.2 as transitionEnd is triggered twice when the next slide is last one.
Just clearTimeout can fix.