### PR TITLE
Round the width of slides

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -60,7 +60,7 @@
       slidePos = new Array(slides.length);
 
       // determine width of each slide
-      width = container.getBoundingClientRect().width || container.offsetWidth;
+      width = Math.round(container.getBoundingClientRect().width || container.offsetWidth);
 
       element.style.width = (slides.length * width) + 'px';
 


### PR DESCRIPTION
This is done to prevent the images from becoming a pixel too small, showing a sliver of the next and/or previous slide.

Fixes #14