### PR TITLE
Prevent scrolling dynamically

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -559,6 +559,10 @@
         } else {
           window.onresize = null;
         }
+      },
+      preventScrolling: function (shouldScroll) {
+        stop();
+        options.disableScroll = shouldScroll;
       }
     };
   };


### PR DESCRIPTION
This PR exposes an extra api function to disable/enable swiping dynamically. It can be useful when you want to display something to end users (ads, messages) and the aim is to prevent them swiping away.