### PR TITLE
Allows control over scrolling without re-rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Swipe exposes a few functions that can be useful for script control of your slid
 
 `slide(index, duration)` slide to set index position (duration: speed of transition in milliseconds)
 
+`disableScrolling(disableScroll)` directly control scrolling (disableScroll: ```true``` to prevent scrolling, ```false``` to enable (default:false) )
+
 ## Browser Support
 
 Swipe is now compatible with all browsers, including IE7+. Swipe works best on devices that support CSS transforms and touch, but can be used without these as well. A few helper methods determine touch and CSS transition support and choose the proper animation methods accordingly.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Swipe exposes a few functions that can be useful for script control of your slid
 
 `slide(index, duration)` slide to set index position (duration: speed of transition in milliseconds)
 
-`disableScrolling(disableScroll)` directly control scrolling (disableScroll: ```true``` to prevent scrolling, ```false``` to enable (default:false) )
+`disableScrolling(disableScroll)` directly control scrolling (disableScroll: same as the config option )
 
 ## Browser Support
 

--- a/swipe.js
+++ b/swipe.js
@@ -524,6 +524,9 @@
         // return total number of slides
         return length;
       },
+      disableScrolling: function (disableScroll) {
+        options.disableScroll = disableScroll
+      },
       kill: function() {
 
         // cancel slideshow


### PR DESCRIPTION
I added a simple hook to toggle scrolling behaviour. Setting ```disableScroll``` via option requires a render(). This caused a flash while the page needlessly reloaded the same content. Any comments are welcome, thanks!