### PR TITLE
Fix for Safari UIWebView crash on Ignored attempt to cancel a touchmove

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -303,7 +303,7 @@
         // if user is not trying to scroll vertically
         if (!isScrolling) {
           // prevent native scrolling
-          event.preventDefault();
+          if (event.cancelable) event.preventDefault();
 
           // stop slideshow
           stop();


### PR DESCRIPTION
Fix for `Error: [Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted`

This issue is crashing Safari UIWebView and the browser is refreshed automatically. Would you consider to merge this PR, please?

#30 